### PR TITLE
Add `model.generate` support

### DIFF
--- a/attention_sinks/generation/utils.py
+++ b/attention_sinks/generation/utils.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict
+
+import torch
+from transformers.generation.utils import GenerationMixin as TGenerationMixin
+from transformers.utils import ModelOutput
+
+
+class GenerationMixin(TGenerationMixin):
+    """
+    This GenerationMixin must be overridden to prevent the `attention_mask`
+    from extending beyond the window size.
+    """
+
+    def _update_model_kwargs_for_generation(
+        self,
+        outputs: ModelOutput,
+        model_kwargs: Dict[str, Any],
+        is_encoder_decoder: bool = False,
+        standardize_cache_format: bool = False,
+    ) -> Dict[str, Any]:
+        # update past_key_values
+        model_kwargs["past_key_values"] = self._extract_past_from_model_output(
+            outputs, standardize_cache_format=standardize_cache_format
+        )
+        if getattr(outputs, "state", None) is not None:
+            model_kwargs["state"] = outputs.state
+
+        # update token_type_ids with last value
+        if "token_type_ids" in model_kwargs:
+            token_type_ids = model_kwargs["token_type_ids"]
+            model_kwargs["token_type_ids"] = torch.cat([token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
+
+        if not is_encoder_decoder:
+            # update attention mask
+            if "attention_mask" in model_kwargs:
+                attention_mask = model_kwargs["attention_mask"]
+                # Only this `if`-statement is changed, it's required to stop the attention_mask from extending itself too far
+                if model_kwargs["attention_mask"].size(-1) == model_kwargs["past_key_values"][0][0].size(2):
+                    model_kwargs["attention_mask"] = torch.cat(
+                        [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))], dim=-1
+                    )
+        else:
+            # update decoder attention mask
+            if "decoder_attention_mask" in model_kwargs:
+                decoder_attention_mask = model_kwargs["decoder_attention_mask"]
+                model_kwargs["decoder_attention_mask"] = torch.cat(
+                    [decoder_attention_mask, decoder_attention_mask.new_ones((decoder_attention_mask.shape[0], 1))],
+                    dim=-1,
+                )
+
+        return model_kwargs

--- a/attention_sinks/models/falcon/modeling_falcon.py
+++ b/attention_sinks/models/falcon/modeling_falcon.py
@@ -35,10 +35,11 @@ from transformers.utils import (
 )
 
 from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
 from attention_sinks.models.falcon.pos_shift import enable_falcon_pos_shift_attention
 
 
-class FalconPreTrainedModel(TFalconPreTrainedModel):
+class FalconPreTrainedModel(GenerationMixin, TFalconPreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,

--- a/attention_sinks/models/gpt_neox/modeling_gpt_neox.py
+++ b/attention_sinks/models/gpt_neox/modeling_gpt_neox.py
@@ -36,12 +36,13 @@ from transformers.utils import (
 )
 
 from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
 from attention_sinks.models.gpt_neox.pos_shift import (
     enable_gpt_neox_pos_shift_attention,
 )
 
 
-class GPTNeoXPreTrainedModel(TGPTNeoXPreTrainedModel):
+class GPTNeoXPreTrainedModel(GenerationMixin, TGPTNeoXPreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,

--- a/attention_sinks/models/llama/modeling_llama.py
+++ b/attention_sinks/models/llama/modeling_llama.py
@@ -22,10 +22,11 @@ from transformers.models.llama.modeling_llama import LLAMA_INPUTS_DOCSTRING
 from transformers.utils import add_start_docstrings_to_model_forward
 
 from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
 from attention_sinks.models.llama.pos_shift import enable_llama_pos_shift_attention
 
 
-class LlamaPreTrainedModel(TLlamaPreTrainedModel):
+class LlamaPreTrainedModel(GenerationMixin, TLlamaPreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,

--- a/attention_sinks/models/mistral/modeling_mistral.py
+++ b/attention_sinks/models/mistral/modeling_mistral.py
@@ -22,10 +22,11 @@ from transformers.models.mistral.modeling_mistral import MISTRAL_INPUTS_DOCSTRIN
 from transformers.utils import add_start_docstrings_to_model_forward
 
 from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
 from attention_sinks.models.mistral.pos_shift import enable_mistral_pos_shift_attention
 
 
-class MistralPreTrainedModel(TMistralPreTrainedModel):
+class MistralPreTrainedModel(GenerationMixin, TMistralPreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,

--- a/attention_sinks/models/mpt/modeling_mpt.py
+++ b/attention_sinks/models/mpt/modeling_mpt.py
@@ -36,9 +36,10 @@ from transformers.utils import (
 )
 
 from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
 
 
-class MptPreTrainedModel(TMptPreTrainedModel):
+class MptPreTrainedModel(GenerationMixin, TMptPreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,


### PR DESCRIPTION
Closes #1 

Hello!

## Pull Request overview
* Prevent crashes for `model.generate`

## Details
The `_update_model_kwargs_for_generation` method in `GenerationMixin` would endlessly grow the `attention_mask` to match the `past_key_values + 1`, which is normally very reasonable. However, with `attention_sinks` we eventually cap the `past_key_values`, so it ended up crashing.

This change very simply prevents the endless growth of the `attention_mask` so it always matches `past_key_values + 1`.

## Usage

```python
import torch
from transformers import AutoTokenizer, TextStreamer, GenerationConfig
from attention_sinks import AutoModelForCausalLM


# model_id = "meta-llama/Llama-2-7b-hf"
# model_id = "mistralai/Mistral-7B-v0.1"
model_id = "mosaicml/mpt-7b"
# model_id = "tiiuae/falcon-7b"
# model_id = "EleutherAI/pythia-6.9b-deduped"

# Load the chosen model and corresponding tokenizer
model = AutoModelForCausalLM.from_pretrained(
    model_id,
    # for efficiency:
    device_map="auto",
    torch_dtype=torch.float16,
    # `attention_sinks`-specific arguments:
    attention_sink_size=4,
    attention_sink_window_size=252,
)
tokenizer = AutoTokenizer.from_pretrained(model_id)
tokenizer.pad_token_id = tokenizer.eos_token_id

# Our input text
text = "Vaswani et al. (2017) introduced the Transformers"

# Encode the text
input_ids = tokenizer.encode(text, return_tensors="pt").to(model.device)

# Print tokens as they're being generated
streamer = TextStreamer(tokenizer)
generated_tokens = model.generate(
    input_ids,
    generation_config=GenerationConfig(
        # use_cache=True is required, the rest can be changed up.
        use_cache=True,
        min_new_tokens=20000,
        max_new_tokens=50000,
        penalty_alpha=0.6,
        top_k=5,
        pad_token_id=tokenizer.pad_token_id,
        eos_token_id=tokenizer.eos_token_id,
    ),
    streamer=streamer,
)
# Decode the final generated text
output_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
```

- Tom Aarsen