### PR TITLE
Completely refactor injection code

### DIFF
--- a/attention_sinks/attention_sink_kv_cache.py
+++ b/attention_sinks/attention_sink_kv_cache.py
@@ -7,16 +7,16 @@ from dataclasses import dataclass
 import torch
 
 
+def slice1d(x, start, end):
+    return x[:, start:end, ...]
+
+
 def slice2d(x, start, end):
     return x[:, :, start:end, ...]
 
 
 def slice3d(x, start, end):
     return x[:, :, :, start:end, ...]
-
-
-def slice1d(x, start, end):
-    return x[:, start:end, ...]
 
 
 DIM_TO_SLICE = {

--- a/attention_sinks/inject_mixin.py
+++ b/attention_sinks/inject_mixin.py
@@ -1,0 +1,130 @@
+import types
+from typing import Callable, Optional
+
+from transformers import PreTrainedModel
+from transformers.utils import logging
+
+from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
+from attention_sinks.generation.utils import GenerationMixin
+
+logger = logging.get_logger(__name__)
+
+MODEL_NAME_MAPPING = {
+    "llama": "LlamaModel",
+    "falcon": "FalconModel",
+    "mpt": "MptModel",
+    "gpt_neox": "GPTNeoXModel",
+    "gptj": "GPTJModel",
+    "mistral": "MistralModel",
+}
+ATTENTION_NAME_MAPPING = {
+    "llama": "LlamaAttention",
+    "falcon": "FalconAttention",
+    "mpt": "MptAttention",
+    "gpt_neox": "GPTNeoXAttention",
+    "gptj": "GPTJAttention",
+    "mistral": "MistralAttention",
+}
+KV_DIM_MAPPING = {
+    "llama": (2, 2),
+    "falcon": (2, 2),
+    "mpt": (2, 2),
+    "gpt_neox": (2, 2),
+    "gptj": (2, 2),
+    "mistral": (2, 2),
+}
+
+
+class InjectAttentionSinksMixin(GenerationMixin):
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        # Separate Attention Sink kwargs from regular kwargs
+        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
+        for key in attention_sink_kwargs:
+            kwargs.pop(key)
+
+        model = super().from_pretrained(
+            pretrained_model_name_or_path,
+            *model_args,
+            **kwargs,
+        )
+        model_type = model.config.model_type
+        if model_type not in MODEL_NAME_MAPPING:
+            raise NotImplementedError(
+                f"`attention_sinks` does not support models with the `{model_type}` architecture at this time."
+            )
+
+        # Enable position shifting attention
+        call_count = cls._inject_pos_shift_attention(model)
+        if call_count is not None:
+            logger.warn(
+                f"[Attention Sinks] Injected Position Shifting into {call_count} attention class{'es' if call_count != 1 else ''}."
+            )
+
+        # Inject the Attention Sink KV Cache to the model
+        call_count = cls._inject_attention_sink_kv_cache(model, **attention_sink_kwargs)
+        logger.warn(
+            f"[Attention Sinks] Injected Attention Sink KV Cache into {call_count} model class{'es' if call_count != 1 else ''}."
+        )
+
+        return model
+
+    @classmethod
+    def _inject_pos_shift_attention(cls, model: PreTrainedModel) -> Optional[int]:
+        model_type = model.config.model_type
+
+        from attention_sinks.models import (
+            falcon_pos_shift_attention_forward,
+            gpt_neox_pos_shift_attention_forward,
+            gptj_pos_shift_attention_forward,
+            llama_pos_shift_attention_forward,
+            mistral_pos_shift_attention_forward,
+        )
+
+        ATTENTION_FORWARD_MAPPING = {
+            "llama": llama_pos_shift_attention_forward,
+            "falcon": falcon_pos_shift_attention_forward,
+            "mpt": None,
+            "gpt_neox": gpt_neox_pos_shift_attention_forward,
+            "gptj": gptj_pos_shift_attention_forward,
+            "mistral": mistral_pos_shift_attention_forward,
+        }
+
+        # Not all models require updated attention forwards
+        if ATTENTION_FORWARD_MAPPING[model_type] is None:
+            return
+
+        def overwrite_forward(module) -> None:
+            module.forward = types.MethodType(ATTENTION_FORWARD_MAPPING[model_type], module)
+
+        return cls._call_modules_by_name(model, ATTENTION_NAME_MAPPING[model_type], overwrite_forward)
+
+    @classmethod
+    def _inject_attention_sink_kv_cache(cls, model, **attention_sink_kwargs) -> int:
+        model_type = model.config.model_type
+        attention_sink_kwargs["k_seq_dim"], attention_sink_kwargs["v_seq_dim"] = KV_DIM_MAPPING[model_type]
+
+        def overwrite_forward(module):
+            # Create the new cache
+            module.attention_sink_kv_cache = AttentionSinkKVCache(**attention_sink_kwargs)
+
+            # Keep track of the old forward method, we need it in the wrapped one
+            old_forward = module.forward
+
+            # Wrap the forward by overriding the past_key_values using the cache
+            def wrapped_forward(self, *args, **kwargs):
+                outputs = old_forward(*args, **kwargs)
+                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
+                return outputs
+
+            module.forward = types.MethodType(wrapped_forward, module)
+
+        return cls._call_modules_by_name(model, MODEL_NAME_MAPPING[model_type], overwrite_forward)
+
+    @classmethod
+    def _call_modules_by_name(cls, module, target_name: str, func: Callable) -> int:
+        if module.__class__.__name__ == target_name:
+            func(module)
+            return 1
+
+        return sum(cls._call_modules_by_name(module, target_name, func) for module in module.children())

--- a/attention_sinks/models/__init__.py
+++ b/attention_sinks/models/__init__.py
@@ -12,6 +12,7 @@ from .falcon import (
     FalconForTokenClassification,
     FalconModel,
     FalconPreTrainedModel,
+    falcon_pos_shift_attention_forward,
 )
 from .gpt_neox import (
     GPTNeoXForCausalLM,
@@ -20,6 +21,7 @@ from .gpt_neox import (
     GPTNeoXForTokenClassification,
     GPTNeoXModel,
     GPTNeoXPreTrainedModel,
+    gpt_neox_pos_shift_attention_forward,
 )
 from .gptj import (
     GPTJForCausalLM,
@@ -27,9 +29,15 @@ from .gptj import (
     GPTJForSequenceClassification,
     GPTJModel,
     GPTJPreTrainedModel,
+    gptj_pos_shift_attention_forward,
 )
-from .llama import LlamaForCausalLM, LlamaForSequenceClassification, LlamaModel
-from .mistral import MistralForCausalLM, MistralForSequenceClassification, MistralModel
+from .llama import LlamaForCausalLM, LlamaForSequenceClassification, LlamaModel, llama_pos_shift_attention_forward
+from .mistral import (
+    MistralForCausalLM,
+    MistralForSequenceClassification,
+    MistralModel,
+    mistral_pos_shift_attention_forward,
+)
 from .mpt import (
     MptForCausalLM,
     MptForQuestionAnswering,

--- a/attention_sinks/models/auto/modeling_auto.py
+++ b/attention_sinks/models/auto/modeling_auto.py
@@ -3,97 +3,25 @@ from transformers import AutoModelForCausalLM as TAutoModelForCausalLM
 from transformers import AutoModelForQuestionAnswering as TAutoModelForQuestionAnswering
 from transformers import AutoModelForSequenceClassification as TAutoModelForSequenceClassification
 from transformers import AutoModelForTokenClassification as TAutoModelForTokenClassification
-from transformers import FalconConfig, GPTJConfig, GPTNeoXConfig, LlamaConfig, MistralConfig, MptConfig
-from transformers.models.auto.modeling_auto import (
-    MODEL_FOR_CAUSAL_LM_MAPPING,
-    MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-    MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-    MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
-    MODEL_MAPPING,
-)
 
-from ..falcon import (
-    FalconForCausalLM,
-    FalconForQuestionAnswering,
-    FalconForSequenceClassification,
-    FalconForTokenClassification,
-    FalconModel,
-)
-from ..gpt_neox import (
-    GPTNeoXForCausalLM,
-    GPTNeoXForQuestionAnswering,
-    GPTNeoXForSequenceClassification,
-    GPTNeoXForTokenClassification,
-    GPTNeoXModel,
-)
-from ..gptj import (
-    GPTJForCausalLM,
-    GPTJForQuestionAnswering,
-    GPTJForSequenceClassification,
-    GPTJModel,
-)
-from ..llama import LlamaForCausalLM, LlamaForSequenceClassification, LlamaModel
-from ..mistral import MistralForCausalLM, MistralForSequenceClassification, MistralModel
-from ..mpt import (
-    MptForCausalLM,
-    MptForQuestionAnswering,
-    MptForSequenceClassification,
-    MptForTokenClassification,
-    MptModel,
-)
-
-MODEL_MAPPING._extra_content = {
-    LlamaConfig: LlamaModel,
-    FalconConfig: FalconModel,
-    MptConfig: MptModel,
-    GPTNeoXConfig: GPTNeoXModel,
-    GPTJConfig: GPTJModel,
-    MistralConfig: MistralModel,
-}
-MODEL_FOR_CAUSAL_LM_MAPPING._extra_content = {
-    LlamaConfig: LlamaForCausalLM,
-    FalconConfig: FalconForCausalLM,
-    MptConfig: MptForCausalLM,
-    GPTNeoXConfig: GPTNeoXForCausalLM,
-    GPTJConfig: GPTJForCausalLM,
-    MistralConfig: MistralForCausalLM,
-}
-MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING._extra_content = {
-    LlamaConfig: LlamaForSequenceClassification,
-    FalconConfig: FalconForSequenceClassification,
-    MptConfig: MptForSequenceClassification,
-    GPTNeoXConfig: GPTNeoXForSequenceClassification,
-    GPTJConfig: GPTJForSequenceClassification,
-    MistralConfig: MistralForSequenceClassification,
-}
-MODEL_FOR_QUESTION_ANSWERING_MAPPING._extra_content = {
-    FalconConfig: FalconForQuestionAnswering,
-    MptConfig: MptForQuestionAnswering,
-    GPTNeoXConfig: GPTNeoXForQuestionAnswering,
-    GPTJConfig: GPTJForQuestionAnswering,
-}
-MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING._extra_content = {
-    FalconConfig: FalconForTokenClassification,
-    MptConfig: MptForTokenClassification,
-    GPTNeoXConfig: GPTNeoXForTokenClassification,
-}
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class AutoModel(TAutoModel):
-    _model_mapping = MODEL_MAPPING
+class AutoModel(InjectAttentionSinksMixin, TAutoModel):
+    pass
 
 
-class AutoModelForCausalLM(TAutoModelForCausalLM):
-    _model_mapping = MODEL_FOR_CAUSAL_LM_MAPPING
+class AutoModelForCausalLM(InjectAttentionSinksMixin, TAutoModelForCausalLM):
+    pass
 
 
-class AutoModelForSequenceClassification(TAutoModelForSequenceClassification):
-    _model_mapping = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+class AutoModelForSequenceClassification(InjectAttentionSinksMixin, TAutoModelForSequenceClassification):
+    pass
 
 
-class AutoModelForQuestionAnswering(TAutoModelForQuestionAnswering):
-    _model_mapping = MODEL_FOR_QUESTION_ANSWERING_MAPPING
+class AutoModelForQuestionAnswering(InjectAttentionSinksMixin, TAutoModelForQuestionAnswering):
+    pass
 
 
-class AutoModelForTokenClassification(TAutoModelForTokenClassification):
-    _model_mapping = MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
+class AutoModelForTokenClassification(InjectAttentionSinksMixin, TAutoModelForTokenClassification):
+    pass

--- a/attention_sinks/models/falcon/__init__.py
+++ b/attention_sinks/models/falcon/__init__.py
@@ -6,3 +6,4 @@ from .modeling_falcon import (
     FalconModel,
     FalconPreTrainedModel,
 )
+from .pos_shift import falcon_pos_shift_attention_forward

--- a/attention_sinks/models/falcon/modeling_falcon.py
+++ b/attention_sinks/models/falcon/modeling_falcon.py
@@ -1,96 +1,15 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import FalconForCausalLM as TFalconForCausalLM
 from transformers import FalconForQuestionAnswering as TFalconForQuestionAnswering
 from transformers import FalconForSequenceClassification as TFalconForSequenceClassification
 from transformers import FalconForTokenClassification as TFalconForTokenClassification
 from transformers import FalconModel as TFalconModel
 from transformers import FalconPreTrainedModel as TFalconPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions
-from transformers.models.falcon.modeling_falcon import _CHECKPOINT_FOR_DOC, _CONFIG_FOR_DOC, FALCON_INPUTS_DOCSTRING
-from transformers.utils import add_code_sample_docstrings, add_start_docstrings_to_model_forward
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
-from attention_sinks.models.falcon.pos_shift import enable_falcon_pos_shift_attention
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class FalconPreTrainedModel(GenerationMixin, TFalconPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(FalconPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # Enable position shifting attention for Falcon
-        enable_falcon_pos_shift_attention(model)
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TFalconModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(FALCON_INPUTS_DOCSTRING)
-            @add_code_sample_docstrings(
-                checkpoint=_CHECKPOINT_FOR_DOC,
-                output_type=BaseModelOutputWithPastAndCrossAttentions,
-                config_class=_CONFIG_FOR_DOC,
-            )
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPastAndCrossAttentions]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all FalconModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class FalconPreTrainedModel(InjectAttentionSinksMixin, TFalconPreTrainedModel):
+    pass
 
 
 class FalconModel(FalconPreTrainedModel, TFalconModel):

--- a/attention_sinks/models/falcon/pos_shift.py
+++ b/attention_sinks/models/falcon/pos_shift.py
@@ -1,12 +1,11 @@
 import math
-import types
 from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 import torch.utils.checkpoint
 
-__all__ = ["enable_falcon_pos_shift_attention"]
+__all__ = ["falcon_pos_shift_attention_forward"]
 
 
 def falcon_pos_shift_attention_forward(
@@ -134,12 +133,3 @@ def falcon_pos_shift_attention_forward(
             return output_tensor, present, attention_probs
         else:
             return output_tensor, present
-
-
-def enable_falcon_pos_shift_attention(model):
-    for name, module in reversed(model._modules.items()):
-        if len(list(module.children())) > 0:
-            enable_falcon_pos_shift_attention(module)
-
-        if "self_attention" == name[-14:]:
-            model._modules[name].forward = types.MethodType(falcon_pos_shift_attention_forward, model._modules[name])

--- a/attention_sinks/models/gpt_neox/__init__.py
+++ b/attention_sinks/models/gpt_neox/__init__.py
@@ -6,3 +6,4 @@ from .modeling_gpt_neox import (
     GPTNeoXModel,
     GPTNeoXPreTrainedModel,
 )
+from .pos_shift import gpt_neox_pos_shift_attention_forward

--- a/attention_sinks/models/gpt_neox/modeling_gpt_neox.py
+++ b/attention_sinks/models/gpt_neox/modeling_gpt_neox.py
@@ -1,102 +1,15 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import GPTNeoXForCausalLM as TGPTNeoXForCausalLM
 from transformers import GPTNeoXForQuestionAnswering as TGPTNeoXForQuestionAnswering
 from transformers import GPTNeoXForSequenceClassification as TGPTNeoXForSequenceClassification
 from transformers import GPTNeoXForTokenClassification as TGPTNeoXForTokenClassification
 from transformers import GPTNeoXModel as TGPTNeoXModel
 from transformers import GPTNeoXPreTrainedModel as TGPTNeoXPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPast
-from transformers.models.gpt_neox.modeling_gpt_neox import (
-    _CHECKPOINT_FOR_DOC,
-    _CONFIG_FOR_DOC,
-    _REAL_CHECKPOINT_FOR_DOC,
-    GPT_NEOX_INPUTS_DOCSTRING,
-)
-from transformers.utils import add_code_sample_docstrings, add_start_docstrings_to_model_forward
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
-from attention_sinks.models.gpt_neox.pos_shift import enable_gpt_neox_pos_shift_attention
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class GPTNeoXPreTrainedModel(GenerationMixin, TGPTNeoXPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(GPTNeoXPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # Enable position shifting attention for GPTNeoX
-        enable_gpt_neox_pos_shift_attention(model)
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TGPTNeoXModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(GPT_NEOX_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
-            @add_code_sample_docstrings(
-                checkpoint=_CHECKPOINT_FOR_DOC,
-                real_checkpoint=_REAL_CHECKPOINT_FOR_DOC,
-                output_type=BaseModelOutputWithPast,
-                config_class=_CONFIG_FOR_DOC,
-            )
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPast]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all GPTNeoXModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class GPTNeoXPreTrainedModel(InjectAttentionSinksMixin, TGPTNeoXPreTrainedModel):
+    pass
 
 
 class GPTNeoXModel(GPTNeoXPreTrainedModel, TGPTNeoXModel):

--- a/attention_sinks/models/gpt_neox/pos_shift.py
+++ b/attention_sinks/models/gpt_neox/pos_shift.py
@@ -3,14 +3,13 @@ Adapted from https://github.com/mit-han-lab/streaming-llm
 """
 
 
-import types
 from typing import Optional, Tuple
 
 import torch
 import torch.utils.checkpoint
-from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXAttention, rotate_half
+from transformers.models.gpt_neox.modeling_gpt_neox import rotate_half
 
-__all__ = ["enable_gpt_neox_pos_shift_attention"]
+__all__ = ["gpt_neox_pos_shift_attention_forward"]
 
 
 def apply_rotary_pos_emb_single(x, cos, sin, position_ids):
@@ -88,12 +87,3 @@ def gpt_neox_pos_shift_attention_forward(
         outputs += (attn_weights,)
 
     return outputs
-
-
-def enable_gpt_neox_pos_shift_attention(model):
-    for name, module in reversed(model._modules.items()):
-        if len(list(module.children())) > 0:
-            enable_gpt_neox_pos_shift_attention(module)
-
-        if isinstance(module, GPTNeoXAttention):
-            module.forward = types.MethodType(gpt_neox_pos_shift_attention_forward, module)

--- a/attention_sinks/models/gptj/__init__.py
+++ b/attention_sinks/models/gptj/__init__.py
@@ -5,3 +5,4 @@ from .modeling_gptj import (
     GPTJModel,
     GPTJPreTrainedModel,
 )
+from .pos_shift import gptj_pos_shift_attention_forward

--- a/attention_sinks/models/gptj/modeling_gptj.py
+++ b/attention_sinks/models/gptj/modeling_gptj.py
@@ -1,101 +1,14 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import GPTJForCausalLM as TGPTJForCausalLM
 from transformers import GPTJForQuestionAnswering as TGPTJForQuestionAnswering
 from transformers import GPTJForSequenceClassification as TGPTJForSequenceClassification
 from transformers import GPTJModel as TGPTJModel
 from transformers import GPTJPreTrainedModel as TGPTJPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPast
-from transformers.models.gptj.modeling_gptj import (
-    _CHECKPOINT_FOR_DOC,
-    _CONFIG_FOR_DOC,
-    _REAL_CHECKPOINT_FOR_DOC,
-    GPTJ_INPUTS_DOCSTRING,
-)
-from transformers.utils import add_code_sample_docstrings, add_start_docstrings_to_model_forward
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
-from attention_sinks.models.gptj.pos_shift import enable_gptj_pos_shift_attention
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class GPTJPreTrainedModel(GenerationMixin, TGPTJPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(GPTJPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # Enable position shifting attention for GPTJ
-        enable_gptj_pos_shift_attention(model)
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TGPTJModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(GPTJ_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
-            @add_code_sample_docstrings(
-                checkpoint=_CHECKPOINT_FOR_DOC,
-                output_type=BaseModelOutputWithPast,
-                config_class=_CONFIG_FOR_DOC,
-                real_checkpoint=_REAL_CHECKPOINT_FOR_DOC,
-            )
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPast]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all GPTJModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class GPTJPreTrainedModel(InjectAttentionSinksMixin, TGPTJPreTrainedModel):
+    pass
 
 
 class GPTJModel(GPTJPreTrainedModel, TGPTJModel):

--- a/attention_sinks/models/llama/__init__.py
+++ b/attention_sinks/models/llama/__init__.py
@@ -1,1 +1,2 @@
 from .modeling_llama import LlamaForCausalLM, LlamaForSequenceClassification, LlamaModel
+from .pos_shift import llama_pos_shift_attention_forward

--- a/attention_sinks/models/llama/modeling_llama.py
+++ b/attention_sinks/models/llama/modeling_llama.py
@@ -1,89 +1,13 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import LlamaForCausalLM as TLlamaForCausalLM
 from transformers import LlamaForSequenceClassification as TLlamaForSequenceClassification
 from transformers import LlamaModel as TLlamaModel
 from transformers import LlamaPreTrainedModel as TLlamaPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPast
-from transformers.models.llama.modeling_llama import LLAMA_INPUTS_DOCSTRING
-from transformers.utils import add_start_docstrings_to_model_forward
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
-from attention_sinks.models.llama.pos_shift import enable_llama_pos_shift_attention
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class LlamaPreTrainedModel(GenerationMixin, TLlamaPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(LlamaPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # Enable position shifting attention for Llama
-        enable_llama_pos_shift_attention(model)
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TLlamaModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(LLAMA_INPUTS_DOCSTRING)
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPast]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all LlamaModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class LlamaPreTrainedModel(InjectAttentionSinksMixin, TLlamaPreTrainedModel):
+    pass
 
 
 class LlamaModel(LlamaPreTrainedModel, TLlamaModel):

--- a/attention_sinks/models/llama/pos_shift.py
+++ b/attention_sinks/models/llama/pos_shift.py
@@ -4,16 +4,15 @@ Adapted from https://github.com/mit-han-lab/streaming-llm
 
 
 import math
-import types
 from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch import nn
-from transformers.models.llama.modeling_llama import LlamaAttention, repeat_kv, rotate_half
+from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
 
-__all__ = ["enable_llama_pos_shift_attention"]
+__all__ = ["llama_pos_shift_attention_forward"]
 
 
 def apply_rotary_pos_emb_single(x, cos, sin, position_ids):
@@ -126,12 +125,3 @@ def llama_pos_shift_attention_forward(
         attn_weights = None
 
     return attn_output, attn_weights, past_key_value
-
-
-def enable_llama_pos_shift_attention(model):
-    for name, module in reversed(model._modules.items()):
-        if len(list(module.children())) > 0:
-            enable_llama_pos_shift_attention(module)
-
-        if isinstance(module, LlamaAttention):
-            model._modules[name].forward = types.MethodType(llama_pos_shift_attention_forward, model._modules[name])

--- a/attention_sinks/models/mistral/__init__.py
+++ b/attention_sinks/models/mistral/__init__.py
@@ -3,3 +3,4 @@ from .modeling_mistral import (
     MistralForSequenceClassification,
     MistralModel,
 )
+from .pos_shift import mistral_pos_shift_attention_forward

--- a/attention_sinks/models/mistral/modeling_mistral.py
+++ b/attention_sinks/models/mistral/modeling_mistral.py
@@ -1,89 +1,13 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import MistralForCausalLM as TMistralForCausalLM
 from transformers import MistralForSequenceClassification as TMistralForSequenceClassification
 from transformers import MistralModel as TMistralModel
 from transformers import MistralPreTrainedModel as TMistralPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPast
-from transformers.models.mistral.modeling_mistral import MISTRAL_INPUTS_DOCSTRING
-from transformers.utils import add_start_docstrings_to_model_forward
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
-from attention_sinks.models.mistral.pos_shift import enable_mistral_pos_shift_attention
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class MistralPreTrainedModel(GenerationMixin, TMistralPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(MistralPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # Enable position shifting attention for Mistral
-        enable_mistral_pos_shift_attention(model)
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TMistralModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(MISTRAL_INPUTS_DOCSTRING)
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPast]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all MistralModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class MistralPreTrainedModel(InjectAttentionSinksMixin, TMistralPreTrainedModel):
+    pass
 
 
 class MistralModel(MistralPreTrainedModel, TMistralModel):

--- a/attention_sinks/models/mistral/pos_shift.py
+++ b/attention_sinks/models/mistral/pos_shift.py
@@ -1,13 +1,12 @@
 import math
-import types
 from typing import Optional, Tuple
 
 import torch
 import torch.utils.checkpoint
 from torch import nn
-from transformers.models.mistral.modeling_mistral import MistralAttention, repeat_kv, rotate_half
+from transformers.models.mistral.modeling_mistral import repeat_kv, rotate_half
 
-__all__ = ["enable_mistral_pos_shift_attention"]
+__all__ = ["mistral_pos_shift_attention_forward"]
 
 
 def apply_rotary_pos_emb_single(x, cos, sin, position_ids):
@@ -100,12 +99,3 @@ def mistral_pos_shift_attention_forward(
         attn_weights = None
 
     return attn_output, attn_weights, past_key_value
-
-
-def enable_mistral_pos_shift_attention(model):
-    for name, module in reversed(model._modules.items()):
-        if len(list(module.children())) > 0:
-            enable_mistral_pos_shift_attention(module)
-
-        if isinstance(module, MistralAttention):
-            model._modules[name].forward = types.MethodType(mistral_pos_shift_attention_forward, model._modules[name])

--- a/attention_sinks/models/mpt/modeling_mpt.py
+++ b/attention_sinks/models/mpt/modeling_mpt.py
@@ -1,101 +1,15 @@
-import os
-import types
-from typing import Optional, Tuple, Union
-
 from transformers import MptForCausalLM as TMptForCausalLM
 from transformers import MptForQuestionAnswering as TMptForQuestionAnswering
 from transformers import MptForSequenceClassification as TMptForSequenceClassification
 from transformers import MptForTokenClassification as TMptForTokenClassification
 from transformers import MptModel as TMptModel
 from transformers import MptPreTrainedModel as TMptPreTrainedModel
-from transformers import PretrainedConfig
-from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions
-from transformers.models.mpt.modeling_mpt import (
-    _CHECKPOINT_FOR_DOC,
-    _CONFIG_FOR_DOC,
-    MPT_INPUTS_DOCSTRING,
-)
-from transformers.utils import (
-    add_code_sample_docstrings,
-    add_start_docstrings_to_model_forward,
-)
 
-from attention_sinks.attention_sink_kv_cache import AttentionSinkKVCache
-from attention_sinks.generation.utils import GenerationMixin
+from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
 
-class MptPreTrainedModel(GenerationMixin, TMptPreTrainedModel):
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
-        *model_args,
-        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
-        ignore_mismatched_sizes: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        revision: str = "main",
-        use_safetensors: bool = None,
-        **kwargs,
-    ) -> None:
-        # Separate Attention Sink kwargs from regular kwargs
-        attention_sink_kwargs = {key: value for key, value in kwargs.items() if key.startswith("attention_sink")}
-        for key in attention_sink_kwargs:
-            kwargs.pop(key)
-
-        model = super(MptPreTrainedModel, cls).from_pretrained(
-            pretrained_model_name_or_path,
-            *model_args,
-            config=config,
-            cache_dir=cache_dir,
-            ignore_mismatched_sizes=ignore_mismatched_sizes,
-            force_download=force_download,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            use_safetensors=use_safetensors,
-            **kwargs,
-        )
-        # MPT already has windowed attention
-
-        # Hackishly attach the Attention Sink KV Cache to the model
-        cls._attach_attention_sink_kv_cache(model, **attention_sink_kwargs)
-
-        return model
-
-    @classmethod
-    def _attach_attention_sink_kv_cache(cls, module, **attention_sink_kwargs):
-        if isinstance(module, TMptModel):
-            # Create the new cache
-            module.attention_sink_kv_cache = AttentionSinkKVCache(
-                **attention_sink_kwargs,
-                k_seq_dim=2,
-                v_seq_dim=2,
-            )
-
-            # Keep track of the old forward method, we need it in the wrapped one
-            old_forward = module.forward
-
-            # Wrap the forward by overriding the past_key_values using the cache
-            @add_start_docstrings_to_model_forward(MPT_INPUTS_DOCSTRING)
-            @add_code_sample_docstrings(
-                checkpoint=_CHECKPOINT_FOR_DOC,
-                output_type=BaseModelOutputWithPastAndCrossAttentions,
-                config_class=_CONFIG_FOR_DOC,
-            )
-            def wrapped_forward(self, *args, **kwargs) -> Union[Tuple, BaseModelOutputWithPastAndCrossAttentions]:
-                outputs = old_forward(*args, **kwargs)
-                outputs.past_key_values = self.attention_sink_kv_cache(outputs.past_key_values)
-                return outputs
-
-            module.forward = types.MethodType(wrapped_forward, module)
-
-        # Recursively call this to find all MptModels
-        for module in reversed(module._modules.values()):
-            if len(list(module.children())) > 0:
-                cls._attach_attention_sink_kv_cache(module, **attention_sink_kwargs)
+class MptPreTrainedModel(InjectAttentionSinksMixin, TMptPreTrainedModel):
+    pass
 
 
 class MptModel(MptPreTrainedModel, TMptModel):


### PR DESCRIPTION
Hello!

## Pull Request overview
* Completely refactor injection code

## Details
The injection is now done at the end of the regular `from_pretrained` call, and is even possible on the `AutoModel...` classes. This was not possible before, and was the big motivation for this refactor. With this change implemented, architectures that require `trust_remote_code=True` can also benefit from `attention_sinks`, such as Qwen.

This also helps a decent bit with code duplication.

- Tom Aarsen