### PR TITLE
Support AutoGPTQ

### DIFF
--- a/attention_sinks/__init__.py
+++ b/attention_sinks/__init__.py
@@ -1,10 +1,11 @@
 __version__ = "0.4.1.dev"
-
+#from auto_gptq import AutoGPTQForCausalLM
 from transformers import AutoTokenizer
 
 from .attention_sink_kv_cache import AttentionSinkKVCache
 from .models import (
     AutoModel,
+    AutoGPTQForCausalLM,
     AutoModelForCausalLM,
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,

--- a/attention_sinks/models/__init__.py
+++ b/attention_sinks/models/__init__.py
@@ -1,5 +1,6 @@
 from .auto import (
     AutoModel,
+    AutoGPTQForCausalLM,
     AutoModelForCausalLM,
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,

--- a/attention_sinks/models/auto/__init__.py
+++ b/attention_sinks/models/auto/__init__.py
@@ -4,4 +4,5 @@ from .modeling_auto import (
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
+    AutoGPTQForCausalLM,
 )

--- a/attention_sinks/models/auto/modeling_auto.py
+++ b/attention_sinks/models/auto/modeling_auto.py
@@ -6,7 +6,9 @@ from transformers import AutoModelForTokenClassification as TAutoModelForTokenCl
 
 from attention_sinks.inject_mixin import InjectAttentionSinksMixin
 
-
+from auto_gptq import AutoGPTQForCausalLM as TAutoGPTQForCausalLM
+class AutoGPTQForCausalLM(InjectAttentionSinksMixin, TAutoGPTQForCausalLM):
+    pass
 class AutoModel(InjectAttentionSinksMixin, TAutoModel):
     pass
 


### PR DESCRIPTION
Can use AutoGPTQ model like TheBloke/Qwen-14B-Chat-GPTQ.
inference code:
```
import torch
from transformers import AutoTokenizer, TextStreamer, GenerationConfig
from attention_sinks import AutoModelForCausalLM,AutoGPTQForCausalLM


# model_id = "meta-llama/Llama-2-7b-hf"
# model_id = "mistralai/Mistral-7B-v0.1"
model_id = "TheBloke/Qwen-14B-Chat-GPTQ"

# model_id = "tiiuae/falcon-7b"
# model_id = "EleutherAI/pythia-6.9b-deduped"
# Note: instruct or chat models also work.

# Load the chosen model and corresponding tokenizer
model = AutoGPTQForCausalLM.from_quantized(
    model_id,
    # for efficiency:
    device_map="auto",
    trust_remote_code=True,
    torch_dtype=torch.float16,
    # `attention_sinks`-specific arguments:
    attention_sink_size=4,
    attention_sink_window_size=252# # <- Low for the sake of faster generation
)
model.eval()
tokenizer = AutoTokenizer.from_pretrained(model_id,trust_remote_code=True)
tokenizer.pad_token_id = tokenizer.eos_token_id

# Our input text
text = "Vaswani et al. (2017) introduced the Transformers"

# Encode the text
#input_ids = tokenizer.encode(text, return_tensors="pt").to(model.device)
input_ids = tokenizer(text, return_tensors="pt").input_ids.to(model.device)
print(input_ids)
with torch.no_grad():
    # A TextStreamer prints tokens as they're being generated
    streamer = TextStreamer(tokenizer)
    generated_tokens = model.generate(
       input_ids=input_ids,
       generation_config=GenerationConfig(
            # use_cache=True is required, the rest can be changed up.
            use_cache=True,
            min_new_tokens=100_000,
            max_new_tokens=1_000_000,
            penalty_alpha=0.6,
            top_k=5,
            pad_token_id=tokenizer.pad_token_id,
            eos_token_id=tokenizer.eos_token_id,
        ),
       streamer=streamer,
    )
    # Decode the final generated text
    output_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)

```